### PR TITLE
Use correct indexes if setting node description

### DIFF
--- a/ibswinfo.sh
+++ b/ibswinfo.sh
@@ -332,7 +332,7 @@ done <<< "$_regs"
         ((e+=1))
     done
     mlxreg_out=$(mlxreg_ext -d "$dev" --reg_name SPZR --set "$val" \
-                            --indexes "swid=0x0" --yes)
+                            --indexes "${rid[SPZR]}" --yes)
     ret=$?
     [[ "$ret" != 0 ]] && {
         err "$mlxreg_out"


### PR DESCRIPTION
If using MFT >=4.23 router_entity is needed in the indexes. This is already added for reading registers but not if writing the node description.