### PR TITLE
Trying to fix fan speed readout for HDR switches

### DIFF
--- a/ibswinfo.sh
+++ b/ibswinfo.sh
@@ -416,8 +416,17 @@ done <<< "$_regs"
     # get active tachos
     at_bmsz=$(htod "$(awk '/tacho_active / {printf $(NF-2)}' \
                       < <(show_reg MFCR))")
-    at_bmsk=$(htob "$(awk '/tacho_active / {printf $NF}' \
-                      <<< "${reg[MFCR]}")" "$at_bmsz")
+    tachos_hex="$(awk '/tacho_active / {printf $NF}' \
+                      <<< "${reg[MFCR]}")"
+    tachos_msb="$(awk '/tacho_active_msb / {printf $NF}' \
+                      <<< "${reg[MFCR]}")"
+    dec_tachos="$(htod $tachos_hex)"
+    htachos="$(dtoh $dec_tachos)"
+
+    dec_tacho_msb="$(htod $tachos_msb)"
+    tachos_msb_hex="$(dtoh $dec_tacho_msb)"
+
+    at_bmsk=$(htob "0x${tachos_msb_hex}${htachos}" "$at_bmsz")
     # gather fan speeds for active tachos
     for (( i=${#at_bmsk}-1; i>0; i-- )); do
         [[ ${at_bmsk:$((i-1)):1} == 1 ]] && at_idxs+="$((at_bmsz-i)) "


### PR DESCRIPTION
As per https://github.com/stanford-rc/ibswinfo/issues/17, it's not possible right now to check all fan speeds on HDR and NDR switches. What I found out (I think) is that these newer switches have more fans under the `tacho_active_msb` index in register MFCR. I tried a sort of hacky way of getting to those fans with existing methods but not really sure if I've achieved anything correct. 
This only works on HDR switches, where it enumerates 12 fans (the correct amount):
```
$ ./ibswinfo.sh -d SW_MT54000_Quantum_Mellanox_Technologies
[...]
fan status         | OK
fan#1 (rpm)        | 5906
fan#2 (rpm)        | 5379
fan#3 (rpm)        | 5959
fan#4 (rpm)        | 5209
fan#5 (rpm)        | 6068
fan#6 (rpm)        | 5293
fan#7 (rpm)        | 5803
fan#8 (rpm)        | 5293
fan#9 (rpm)        | 5906
fan#12 (rpm)       | 5293
fan#13 (rpm)       | 7808
fan#14 (rpm)       | 5312
-------------------------------------------------
```
Doing it on an NDR switch (14 fans) yields weird results (I think due to the fact it needs 17 bits to enumerate all the fans, if I understand the logic of it correctly):
```
$ ./ibswinfo.sh -d SW_MT54002_Quantum-2_Mellanox_Technologies
[...]
fan status         | OK
fan#1 (rpm)        | 6754
fan#2 (rpm)        | 5964
fan#3 (rpm)        | 6720
fan#4 (rpm)        | 5884
fan#5 (rpm)        | 6859
fan#6 (rpm)        | 6018
fan#7 (rpm)        | 6824
fan#8 (rpm)        | 5964
fan#9 (rpm)        | 6754
fan#12 (rpm)       | 5884
fan#13 (rpm)       | 6824
fan#14 (rpm)       | 5807
fan#15 (rpm)       | 0
-------------------------------------------------
```
I hope this can be in any way useful and not a dead end. 