### PR TITLE
Prevents catching 'num_of_modules_per_system'

### DIFF
--- a/ibswinfo.sh
+++ b/ibswinfo.sh
@@ -388,7 +388,7 @@ done <<< "$_regs"
 # vitals and status
 [[ ! $out =~ inventory ]] && {
     # number of ports
-    _np=$(awk '/num_of_modules/ {printf $NF}' <<< "${reg[MGPIR]}")
+    _np=$(awk '/num_of_modules / {printf $NF}' <<< "${reg[MGPIR]}")
     if [[ $_np =~ ^0x ]]; then
         np=$(htod "$_np")
     else # try to get that from the SM


### PR DESCRIPTION
Using mst 4.31.0-149 while querying a QM8790, I noticed that the `-T` option failed and the number of ports was incorrect:

```
# ibswinfo.sh -d lid-3 -T
/usr/local/sbin/ibswinfo.sh: xrealloc: cannot allocate 18446744071562067968 bytes
# ibswinfo.sh -d lid-3
=================================================
Quantum Mellanox Technologies
=================================================
part number        | P10774-B21
serial number      | …
product name       | Jaguar Unmng IB 200
revision           | B1
ports              | 171798691880
PSID               | …
GUID               | …
firmware version   | 27.2014.2084
```

I found that the code was catching the number of ports (0x28) twice:

```
# mlxreg_ext -d lid-3 --reg_name MGPIR --get
Sending access register...

Field Name                   | Data
==========================================
num_of_devices               | 0x00000000
num_of_modules_per_system    | 0x00000028
devices_per_flash            | 0x00000000
device_type                  | 0x00000000
slot_index                   | 0x00000000
num_of_modules               | 0x00000028
num_of_slots                 | 0x00000000
max_modules_per_slot         | 0x00000028
num_of_resource_modules      | 0x00000000
==========================================
# mlxreg_ext -d lid-3 --reg_name MGPIR --get | awk '/num_of_modules/ {printf $NF}'
0x000000280x00000028
```

Adding a space at the end of the awk pattern prevents this behavior.